### PR TITLE
New Raster Context Interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,6 @@ CMakeUserPresets.json
 # test output artifacts
 tests/data/success_*.png
 tests/data/failed_*.png
+
+# local development files
+scratchpad.ipynb

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,6 @@
         "cstdint": "cpp",
         "algorithm": "cpp"
     },
-    "cmake.sourceDirectory": "${workspaceFolder}/src"
+    "cmake.sourceDirectory": "${workspaceFolder}/src",
+    "notebook.formatOnSave.enabled": true
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Sushi
-Optimized implementations of rasterized triangle fused draw-MSE-loss
+Optimized implementations of rasterized triangle fused draw+loss
 
 ## Quickstart
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "sushi"
 version = "0.1.0"
-description = "Optimized implementations of triangle rasterization for MSE loss."
+description = "Optimized implementations of triangle rasterization for loss calculation."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [

--- a/sushi/__init__.py
+++ b/sushi/__init__.py
@@ -1,4 +1,4 @@
-"""Sushi: Optimized implementations of triangle rasterization for MSE loss."""
+"""Sushi: Optimized implementations of triangle rasterization for loss calculation."""
 
 from sushi.backend_numpy import NumpyRasterBackend
 from sushi.backend_opencv import OpenCVRasterBackend
@@ -12,7 +12,7 @@ try:
 except ImportError:
     _HAS_CPP = False
 
-from sushi.utils import RasterBackend, np_image_mse
+from sushi.utils import RasterBackend, np_image_loss
 
 __all__ = [
     "RasterBackend",
@@ -20,7 +20,7 @@ __all__ = [
     "OpenCVRasterBackend",
     "OpenGLRasterBackend",
     "PillowRasterBackend",
-    "np_image_mse",
+    "np_image_loss",
 ]
 
 if _HAS_CPP:

--- a/sushi/backend/pillow.py
+++ b/sushi/backend/pillow.py
@@ -10,10 +10,9 @@ from sushi.interface import (
     Backend,
     Config,
     Context,
-    requires_count_pixels_support,
-    requires_draw_support,
-    requires_drawloss_support,
-    requires_target_image,
+    DrawContext,
+    DrawLossContext,
+    calculate_drawloss_using_draw_context,
 )
 from sushi.utils import (
     check_color_rgb,
@@ -25,122 +24,126 @@ from sushi.utils import (
 )
 
 
-class PillowBackend(ABC):
-    name: ClassVar[str] = "pillow"
-
-    @override
-    @classmethod
-    def list_implementations(cls: type["Backend"]) -> list[type["Config"]]:
-        """List all available configuration implementations for this backend.
-
-        Returns:
-            A list of configuration classes that can be used with this backend.
-        """
-        return [PillowConfig]
-
-    @override
-    @classmethod
-    def create_context(
-        cls: type["Backend"],
-        background_image: NDArray[np.uint8],
-        target_image: Optional[NDArray[np.uint8]] = None,
-        config: Optional[Config] = None,
-    ) -> Context:
-        if config is None:
-            config = PillowConfig()
-
-        if not isinstance(config, PillowConfig):
-            raise TypeError(
-                f"Config must be an instance of PillowConfig, got {type(config)}"
-            )
-        return PillowContext(background_image, target_image=target_image, config=config)
-
-
 class PillowConfig(Config):
     pass
 
 
-class PillowContext(Context):
-    name: ClassVar[str] = "context_pillow"
-
-    supports_draw: ClassVar[bool] = True
-    supports_drawloss: ClassVar[bool] = True
-    supports_count_pixels: ClassVar[bool] = True
+class PillowDrawContext(DrawContext):
+    """A drawing context that uses the ImageDraw module from the Pillow library."""
 
     def __init__(
         self,
-        background_image: NDArray[np.uint8],
         *,
-        target_image: Optional[NDArray[np.uint8]] = None,
+        background_image: NDArray[np.uint8],
         config: PillowConfig,
     ) -> None:
-        super().__init__(
-            background_image=background_image,
-            target_image=target_image,
-            config=config,
-        )
-        self.pil_background = Image.fromarray(self.background_image, mode="RGB")
-        if self.target_image is not None:
-            self.pil_target = Image.fromarray(self.target_image, mode="RGB")
+        check_image_rgb(background_image)
+        self.config = config
 
-        if not isinstance(config, PillowConfig):
-            raise TypeError(
-                f"Config must be an instance of PillowConfig, got {type(config)}"
-            )
+        self._pil_background = Image.fromarray(background_image).convert("RGB")
+        self.pil_draw_context = ImageDraw.Draw(self._pil_background, "RGBA")
 
     @override
-    @requires_draw_support
+    def clone(self) -> "PillowDrawContext":
+        out_obj = self.__new__(self.__class__)
+        out_obj.config = self.config
+        out_obj._pil_background = self._pil_background.copy()
+        out_obj.pil_draw_context = ImageDraw.Draw(out_obj._pil_background, "RGBA")
+        return out_obj
+
+    @override
+    def get_image(self) -> NDArray[np.uint8]:
+        return np.array(self._pil_background, dtype=np.uint8)
+
+    @override
     def draw_inplace(
         self,
         vertices: NDArray[np.int32],
         color: NDArray[np.uint8],
     ) -> None:
+        check_triangle_vertices(vertices)
         check_color_rgba(color)
-        draw = ImageDraw.Draw(self.pil_background, "RGBA")
-        draw.polygon([tuple(v) for v in vertices], fill=tuple(color))
-        self.background_image = np.array(self.pil_background, dtype=np.uint8)
+        self.pil_draw_context.polygon([tuple(v) for v in vertices], fill=tuple(color))
+
+
+class PillowDrawLossContext(DrawLossContext):
+    """A drawloss context that uses the ImageDraw module from the Pillow library"""
 
     @override
-    @requires_draw_support
-    def draw(
+    def __init__(
         self,
-        vertices: NDArray[np.int32],
-        color: NDArray[np.uint8],
-    ) -> NDArray[np.uint8]:
-        check_color_rgba(color)
-        new_image = self.pil_background.copy()
-        draw = ImageDraw.Draw(new_image, "RGBA")
-        draw.polygon([tuple(v) for v in vertices], fill=tuple(color))
-        return np.array(new_image, dtype=np.uint8)
+        *,
+        background_image: NDArray[np.uint8],
+        target_image: NDArray[np.uint8],
+        config: PillowConfig,
+        **kwargs: Any,
+    ) -> None:
+        self.draw_context = PillowDrawContext(
+            background_image=background_image, config=config, **kwargs
+        )
+        check_image_rgb(target_image)
+        if background_image.shape != target_image.shape:
+            raise ValueError(
+                "Background image and target image must have the same shape, "
+                f"got {background_image.shape} and {target_image.shape}"
+            )
+        self._target_image_np = target_image
 
     @override
-    @requires_count_pixels_support
-    def count_pixels(
-        self,
-        vertices: NDArray[np.int32],
-    ) -> int:
-        blank_image = Image.new("L", self.pil_background.size, 0)
-        draw = ImageDraw.Draw(blank_image, "L")
-        draw.polygon([tuple(v) for v in vertices], fill=1)
-        mask = np.array(blank_image, dtype=np.uint8)
-        return int(np.sum(mask))
+    def clone(self) -> "PillowDrawLossContext":
+        out_obj = self.__new__(self.__class__)
+        out_obj.draw_context = self.draw_context.clone()
+        out_obj._target_image_np = self._target_image_np.copy()
+        return out_obj
 
     @override
-    @requires_drawloss_support
-    @requires_target_image
     def drawloss(
-        self,
-        vertices: NDArray[np.int32],
-        color: NDArray[np.uint8],
+        self, vertices: NDArray[np.int32], colors: NDArray[np.uint8]
     ) -> NDArray[np.int64]:
-        current_loss = np_image_loss(self.background_image, self.target_image)
+        return calculate_drawloss_using_draw_context(
+            context=self.draw_context,
+            target_image=self._target_image_np,
+            vertices=vertices,
+            colors=colors,
+        )
 
-        losses = np.empty(len(vertices), dtype=np.int64)
-        for i, (v, c) in enumerate(zip(vertices, color)):
-            check_triangle_vertices(v)
-            check_color_rgba(c)
-            out = self.draw(v, c)
-            new_loss = np_image_loss(out, self.target_image)
-            losses[i] = new_loss - current_loss
 
-        return losses
+class PillowBackend(Backend):
+    name: ClassVar[str] = "pillow"
+
+    @classmethod
+    @override
+    def create_draw_context(
+        cls: type["PillowBackend"],
+        *,
+        background_image: NDArray[np.uint8],
+        config: Optional[Config] = None,
+    ) -> DrawContext:
+        if config is None:
+            config = PillowConfig()
+        if not isinstance(config, PillowConfig):
+            raise TypeError(
+                f"Config must be an instance of PillowConfig, got {type(config)}"
+            )
+        return PillowDrawContext(background_image=background_image, config=config)
+
+    @classmethod
+    @override
+    def create_drawloss_context(
+        cls: type["PillowBackend"],
+        *,
+        background_image: NDArray[np.uint8],
+        target_image: NDArray[np.uint8],
+        config: Optional[Config] = None,
+    ) -> DrawLossContext:
+        if config is None:
+            config = PillowConfig()
+        if not isinstance(config, PillowConfig):
+            raise TypeError(
+                f"Config must be an instance of PillowConfig, got {type(config)}"
+            )
+        return PillowDrawLossContext(
+            background_image=background_image,
+            target_image=target_image,
+            config=config,
+        )

--- a/sushi/backend/pillow.py
+++ b/sushi/backend/pillow.py
@@ -1,0 +1,146 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, ClassVar, Optional, Union, override
+
+import numpy as np
+from numpy.typing import NDArray
+from PIL import Image, ImageDraw
+
+from sushi.interface import (
+    Backend,
+    Config,
+    Context,
+    requires_count_pixels_support,
+    requires_draw_support,
+    requires_drawloss_support,
+    requires_target_image,
+)
+from sushi.utils import (
+    check_color_rgb,
+    check_color_rgba,
+    check_image_rgb,
+    check_image_shape,
+    check_triangle_vertices,
+    np_image_loss,
+)
+
+
+class PillowBackend(ABC):
+    name: ClassVar[str] = "pillow"
+
+    @override
+    @classmethod
+    def list_implementations(cls: type["Backend"]) -> list[type["Config"]]:
+        """List all available configuration implementations for this backend.
+
+        Returns:
+            A list of configuration classes that can be used with this backend.
+        """
+        return [PillowConfig]
+
+    @override
+    @classmethod
+    def create_context(
+        cls: type["Backend"],
+        background_image: NDArray[np.uint8],
+        target_image: Optional[NDArray[np.uint8]] = None,
+        config: Optional[Config] = None,
+    ) -> Context:
+        if config is None:
+            config = PillowConfig()
+
+        if not isinstance(config, PillowConfig):
+            raise TypeError(
+                f"Config must be an instance of PillowConfig, got {type(config)}"
+            )
+        return PillowContext(background_image, target_image=target_image, config=config)
+
+
+class PillowConfig(Config):
+    pass
+
+
+class PillowContext(Context):
+    name: ClassVar[str] = "context_pillow"
+
+    supports_draw: ClassVar[bool] = True
+    supports_drawloss: ClassVar[bool] = True
+    supports_count_pixels: ClassVar[bool] = True
+
+    def __init__(
+        self,
+        background_image: NDArray[np.uint8],
+        *,
+        target_image: Optional[NDArray[np.uint8]] = None,
+        config: PillowConfig,
+    ) -> None:
+        super().__init__(
+            background_image=background_image,
+            target_image=target_image,
+            config=config,
+        )
+        self.pil_background = Image.fromarray(self.background_image, mode="RGB")
+        if self.target_image is not None:
+            self.pil_target = Image.fromarray(self.target_image, mode="RGB")
+
+        if not isinstance(config, PillowConfig):
+            raise TypeError(
+                f"Config must be an instance of PillowConfig, got {type(config)}"
+            )
+
+    @override
+    @requires_draw_support
+    def draw_inplace(
+        self,
+        vertices: NDArray[np.int32],
+        color: NDArray[np.uint8],
+    ) -> None:
+        check_color_rgba(color)
+        draw = ImageDraw.Draw(self.pil_background, "RGBA")
+        draw.polygon([tuple(v) for v in vertices], fill=tuple(color))
+        self.background_image = np.array(self.pil_background, dtype=np.uint8)
+
+    @override
+    @requires_draw_support
+    def draw(
+        self,
+        vertices: NDArray[np.int32],
+        color: NDArray[np.uint8],
+    ) -> NDArray[np.uint8]:
+        check_color_rgba(color)
+        new_image = self.pil_background.copy()
+        draw = ImageDraw.Draw(new_image, "RGBA")
+        draw.polygon([tuple(v) for v in vertices], fill=tuple(color))
+        return np.array(new_image, dtype=np.uint8)
+
+    @override
+    @requires_count_pixels_support
+    def count_pixels(
+        self,
+        vertices: NDArray[np.int32],
+    ) -> int:
+        blank_image = Image.new("L", self.pil_background.size, 0)
+        draw = ImageDraw.Draw(blank_image, "L")
+        draw.polygon([tuple(v) for v in vertices], fill=1)
+        mask = np.array(blank_image, dtype=np.uint8)
+        return int(np.sum(mask))
+
+    @override
+    @requires_drawloss_support
+    @requires_target_image
+    def drawloss(
+        self,
+        vertices: NDArray[np.int32],
+        color: NDArray[np.uint8],
+    ) -> NDArray[np.int64]:
+        current_loss = np_image_loss(self.background_image, self.target_image)
+
+        losses = np.empty(len(vertices), dtype=np.int64)
+        for i, (v, c) in enumerate(zip(vertices, color)):
+            check_triangle_vertices(v)
+            check_color_rgba(c)
+            out = self.draw(v, c)
+            new_loss = np_image_loss(out, self.target_image)
+            losses[i] = new_loss - current_loss
+
+        return losses

--- a/sushi/interface.py
+++ b/sushi/interface.py
@@ -1,0 +1,411 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, ClassVar, Generic, Optional, Self, TypeVar, Union
+
+import numpy as np
+from numpy.typing import NDArray
+
+from sushi.utils import (
+    check_color_rgb,
+    check_color_rgba,
+    check_image_rgb,
+    check_image_shape,
+    check_triangle_vertices,
+    np_image_loss,
+)
+
+
+class Config(ABC):
+    """Abstract base class for context configuration objects."""
+
+    supports_draw: ClassVar[bool] = False
+    """Whether the configuration is compatible with DrawContext usage."""
+
+    supports_drawloss: ClassVar[bool] = False
+    """Whether the configuration is compatible with DrawLossContext usage."""
+
+    @abstractmethod
+    def name(self) -> str:
+        """Get the name of the configuration.
+
+        Returns:
+            The name of the configuration.
+        """
+        pass
+
+
+class Context(ABC):
+    """Abstract base class for rendering context."""
+
+    @abstractmethod
+    def clone(self) -> "Self":
+        """
+        Creates a new context with an identical but independent copy of the internal
+        state.
+
+        Backends must implement this to perform safe and efficient copying
+        (e.g., on-device data for GPU contexts).
+        """
+        pass
+
+
+class DrawContext(Context):
+    """Abstract base class for rendering contexts that support drawing triangles.
+
+    The state of the context can be modified by drawing triangles onto it using
+    `draw_inplace()`. To access the current image, use `get_image()`.
+
+    Alternatively, triangles can be drawn without modifying the context's state
+    using `draw()`, which returns a new image with the triangle drawn on it.
+    Performing `draw()` may involve copying the context's internal state,
+    so it is generally less efficient than `draw_inplace()`.
+    """
+
+    def __init__(
+        self,
+        *,
+        background_image: NDArray[np.uint8],
+        config: Config,
+    ) -> None:
+        """Initialize the drawing context.
+
+        Args:
+            background_image: The background image as a NumPy array of shape (H, W, 3)
+                with dtype np.uint8.
+            config: A configuration object specific to the backend.
+
+        Raises:
+            ValueError: If the images do not have the correct shape or type.
+        """
+        check_image_rgb(background_image)
+        self.config = config
+
+    @abstractmethod
+    def get_image(self) -> NDArray[np.uint8]:
+        """Get the current background image.
+
+        Returns:
+            The current background image as a NumPy array of shape (H, W, 3)
+            with dtype np.uint8.
+        """
+        pass
+
+    @abstractmethod
+    def draw_inplace(
+        self,
+        vertices: NDArray[np.int32],
+        color: NDArray[np.uint8],
+    ) -> None:
+        """Draw a triangle onto the context's background image in-place.
+        The context's state will be modified.
+
+        Args:
+            vertices: The vertices of the triangle, an array of shape (3, 2)
+                with dtype np.int32 representing the (x, y) coordinates of the
+                triangle's corners, with the origin at the top-left corner of the image.
+            color: The color of the triangle, an array of shape (4,) with
+                dtype np.uint8 representing the RGBA color.
+        """
+        pass
+
+    def draw(
+        self,
+        vertices: NDArray[np.int32],
+        color: NDArray[np.uint8],
+    ) -> NDArray[np.uint8]:
+        """Draw a triangle onto the context's background image and return a new image.
+        The context's state will not be modified.
+
+        By default, this method creates a clone of the context and performs
+        `draw_inplace()` on the clone. Backends may override this method to
+        provide a more efficient implementation.
+
+        Args:
+            vertices: The vertices of the triangle, an array of shape (3, 2)
+                with dtype np.int32 representing the (x, y) coordinates of the
+                triangle's corners, with the origin at the top-left corner of the image.
+            color: The color of the triangle, an array of shape (4,) with
+                dtype np.uint8 representing the RGBA color.
+
+        Returns:
+            A new image as a NumPy array of shape (H, W, 3) with dtype np.uint8
+            representing the background image with the triangle drawn on it.
+        """
+        temp_context = self.clone()
+        temp_context.draw_inplace(vertices, color)
+        return temp_context.get_image()
+
+
+class DrawLossContext(Context):
+    """Abstract base class for rendering contexts that support mutation-free
+    Sum of Squared Errors (SSE) fused draw+loss computation.
+
+    See `drawloss()` for details.
+    """
+
+    def __init__(
+        self,
+        *,
+        background_image: NDArray[np.uint8],
+        target_image: NDArray[np.uint8],
+        config: Config,
+    ) -> None:
+        """Initialize the draw loss context.
+
+        Args:
+            background_image: The background image as a NumPy array of shape (H, W, 3)
+                with dtype np.uint8.
+            target_image: The target image as a NumPy array of shape (H, W, 3) with
+                dtype np.uint8. Must be provided if the backend supports drawloss.
+            config: A configuration object specific to the backend.
+
+        Raises:
+            ValueError: If the images do not have the correct shape or type.
+        """
+        check_image_rgb(background_image)
+        check_image_rgb(target_image)
+        if background_image.shape != target_image.shape:
+            msg = "Target image must have the same shape as background image."
+            raise ValueError(msg)
+
+        self.config = config
+
+    @abstractmethod
+    def drawloss(
+        self,
+        vertices: NDArray[np.int32],
+        color: NDArray[np.uint8],
+    ) -> NDArray[np.int64]:
+        """Compute the change in Sum of Squares Error loss between the context's
+        background image and target image that would result from drawing a triangle
+        with the given vertices and color atop the background image.
+
+        This is a batch operation, taking an array of triangles and colors, and
+        computing the output values independently for each. For scalar operation,
+        just pass a single-element array.
+
+        This method does not mutate the context's background or target images, but
+        it may temporarily mutate them during its computation.
+        It is therefore not guaranteed to be thread-safe.
+
+        Args:
+            vertices: The vertices of the triangles, an array of shape (N, 3, 2)
+                with dtype np.int32 representing the (x, y) coordinates of the
+                triangles' corners, with the origin at the top-left corner of the image.
+            color: The colors of the triangles, an array of shape (N, 4) with
+                dtype np.uint8 representing the RGBA colors.
+
+        Returns:
+            An array of shape (N,) with dtype np.int64 representing the change in
+            Sum of Squares Error loss for each triangle.
+        """
+        pass
+
+
+class Backend(ABC):
+    """Abstract base class for backends."""
+
+    name: ClassVar[str] = "abc"
+    """Name of the backend."""
+
+    @abstractmethod
+    @classmethod
+    def list_implementations(cls: type["Backend"]) -> list[type["Config"]]:
+        """List all available configuration implementations for this backend.
+
+        Configuration classes define `supports_draw` and `supports_drawloss`
+        class variables to indicate whether they are compatible with the respective
+        context types, see `Backend.create_draw_context()` and
+        `Backend.create_drawloss_context()`.
+
+        Returns:
+            A list of configuration classes that can be used with this backend.
+        """
+        pass
+
+    # @abstractmethod
+    # @classmethod
+    # def create_draw_context
+
+    @abstractmethod
+    @classmethod
+    def create_context(
+        cls: type["Backend"],
+        background_image: NDArray[np.uint8],
+        target_image: Optional[NDArray[np.uint8]] = None,
+        config: Optional["Config"] = None,
+    ) -> "Context":
+        """Create a rendering context for this backend. This method will return
+        different context implementations depending on the provided configuration.
+
+        The configuration must be one of the implementations returned by
+        `list_implementations()`.
+
+        Args:
+            background_image: The background image as a NumPy array of shape (H, W, 3)
+                with dtype np.uint8.
+            target_image: The target image as a NumPy array of shape (H, W, 3) with
+                dtype np.uint8. Must be provided if the backend supports drawloss.
+            config: A configuration object specific to the backend, or None to use
+                a default configuration.
+
+        Returns:
+            A rendering context for this backend.
+        """
+        pass
+
+
+# class Context(ABC):
+#     """Abstract base class for rendering context."""
+
+#     name: ClassVar[str] = "abc"
+#     """Name of the context."""
+
+#     supports_draw: ClassVar[bool] = False
+#     """Whether the context supports drawing triangles."""
+
+#     supports_drawloss: ClassVar[bool] = False
+#     """Whether the context supports mutation-free MSE draw loss computation."""
+
+#     supports_count_pixels: ClassVar[bool] = False
+#     """Whether the context supports counting affected pixels."""
+
+#     def __init__(
+#         self,
+#         background_image: NDArray[np.uint8],
+#         *,
+#         target_image: Optional[NDArray[np.uint8]] = None,
+#         config: Config,
+#     ) -> None:
+#         """Initialize the rendering context.
+
+#         Args:
+#             background_image: The background image as a NumPy array of shape (H, W, 3)
+#                 with dtype np.uint8.
+#             target_image: The target image as a NumPy array of shape (H, W, 3) with
+#                 dtype np.uint8. Must be provided
+#             config: A configuration object specific to the backend.
+
+#         Raises:
+#             ValueError: If the images do not have the correct shape or type.
+#         """
+#         assert background_image is not None, "Background image must be provided."
+#         check_image_shape(background_image)
+#         check_image_rgb(background_image)
+#         self.background_image = background_image
+#         self.height, self.width, _ = background_image.shape
+
+#         if target_image is not None:
+#             if not self.supports_drawloss:
+#                 raise ValueError(
+#                     f"{self.__class__.__name__} does not support target images."
+#                 )
+#             check_image_shape(target_image)
+#             check_image_rgb(target_image)
+#             if target_image.shape != background_image.shape:
+#                 msg = "Target image must have the same shape as background image."
+#                 raise ValueError(msg)
+
+#         self.target_image = target_image
+
+#         self.config = config
+
+#     @abstractmethod
+#     @requires_draw_support
+#     def draw_inplace(
+#         self,
+#         vertices: NDArray[np.int32],
+#         color: NDArray[np.uint8],
+#     ) -> None:
+#         """Draw a triangle onto the context's background image in-place.
+#         The background image will be modified.
+
+#         Args:
+#             vertices: The vertices of the triangle, an array of shape (3, 2)
+#                 with dtype np.int32 representing the (x, y) coordinates of the
+#                 triangle's corners, with the origin at the top-left corner of the image.
+#             color: The color of the triangle, an array of shape (4,) with
+#                 dtype np.uint8 representing the RGBA color.
+#         """
+#         pass
+
+#     @abstractmethod
+#     @requires_draw_support
+#     def draw(
+#         self,
+#         vertices: NDArray[np.int32],
+#         color: NDArray[np.uint8],
+#     ) -> NDArray[np.uint8]:
+#         """Draw a triangle onto the context's background image and return a new image.
+#         The background image will not be modified.
+
+#         Args:
+#             vertices: The vertices of the triangle, an array of shape (3, 2)
+#                 with dtype np.int32 representing the (x, y) coordinates of the
+#                 triangle's corners, with the origin at the top-left corner of the image.
+#             color: The color of the triangle, an array of shape (4,) with
+#                 dtype np.uint8 representing the RGBA color.
+
+#         Returns:
+#             A new image as a NumPy array of shape (H, W, 3) with dtype np.uint8
+#             representing the background image with the triangle drawn on it.
+#         """
+#         pass
+
+#     @abstractmethod
+#     @requires_count_pixels_support
+#     def count_pixels(
+#         self,
+#         vertices: NDArray[np.int32],
+#     ) -> int:
+#         """Count the number of pixels that would be affected by drawing a triangle.
+
+#         Generally, this method is used for debugging and is not guaranteed to be
+#         well-optimized.
+
+#         This method does not mutate the context's background or target images, but
+#         it may temporarily replace them during its computation.
+#         It is therefore not thread-safe.
+
+#         Args:
+#             vertices: The vertices of the triangle, an array of shape (3, 2)
+#                 with dtype np.int32 representing the (x, y) coordinates of the
+#                 triangle's corners, with the origin at the top-left corner of the image.
+
+#         Returns:
+#             The number of pixels that would be affected by drawing the triangle.
+#         """
+#         pass
+
+#     @abstractmethod
+#     @requires_drawloss_support
+#     @requires_target_image
+#     def drawloss(
+#         self,
+#         vertices: NDArray[np.int32],
+#         color: NDArray[np.uint8],
+#     ) -> NDArray[np.int64]:
+#         """Compute the change in Sum of Squares Error loss between the context's
+#         background image and target image that would result from drawing a triangle
+#         with the given vertices and color atop the background image.
+
+#         This is a batch operation, taking an array of triangles and colors, and
+#         computing the output values independently for each. For scalar operation,
+#         pass a single-element array.
+
+#         This method does not mutate the context's background or target images, but
+#         it may temporarily replace them during its computation.
+#         It is therefore not guaranteed to be thread-safe.
+
+#         Args:
+#             vertices: The vertices of the triangles, an array of shape (N, 3, 2)
+#                 with dtype np.int32 representing the (x, y) coordinates of the
+#                 triangles' corners, with the origin at the top-left corner of the image.
+#             color: The colors of the triangles, an array of shape (N, 4) with
+#                 dtype np.uint8 representing the RGBA colors.
+
+#         Returns:
+#             An array of shape (N,) with dtype np.int64 representing the change in
+#             Sum of Squares Error loss for each triangle.
+#         """
+#         pass

--- a/sushi/utils.py
+++ b/sushi/utils.py
@@ -36,25 +36,26 @@ def check_triangle_vertices(vertices: NDArray[np.int32]) -> None:
     assert vertices.dtype == np.int32  # int32 pixel coordinates
 
 
-def np_image_mse(
+def np_image_loss(
     image1: NDArray[np.uint8],
     image2: NDArray[np.uint8],
-) -> float:
-    """Compute the mean squared error between two images.
+) -> int:
+    """Compute the sum of squared error between two images.
+    Dividing the output by `width * height * 3` will produce a normalized MSE.
 
     Args:
         image1: The first image, an array of shape (H, W, 3) with dtype np.uint8.
         image2: The second image, an array of shape (H, W, 3) with dtype np.uint8.
 
     Returns:
-        The mean squared error between the two images.
+        The sum of squared error values between the two images.
     """
     check_image_rgb(image1)
     check_image_rgb(image2)
     assert image1.shape == image2.shape
 
-    mse = np.mean((image1.astype(np.int64) - image2.astype(np.int64)) ** 2)
-    return float(mse)
+    mse = np.sum((image1.astype(np.int64) - image2.astype(np.int64)) ** 2)
+    return int(mse.item())
 
 
 class RasterBackend(ABC):


### PR DESCRIPTION
# Overview

- Added a new interface for rasterization. This style now has "Context" objects for rasterization sessions, which will make it much easier to perform expensive input preparation (swizzling, upload to GPU, cast to PIL Image, etc.) with as much reuse as possible. Also features a `clone()` method for easy data movement without needing to fully re-initialize the context.
- Updated the Pillow backend as an example of the migration
- Updated the tests with the new Pillow backend and interface style.

# Next Steps

- The rest of the backends need to be updated
- CPP Backend with efficient drawloss implementations
- CUDA Backend with efficient batched drawloss