### PR TITLE
Overhaul testing with more feature and config coverage

### DIFF
--- a/src/sushi_cuda/include/sushi_cuda/cuda_backend.cuh
+++ b/src/sushi_cuda/include/sushi_cuda/cuda_backend.cuh
@@ -114,6 +114,25 @@ public:
         if (num_triangles == 0)
             return;
 
+        // Ensure the same winding order for all triangles
+        for (int i = 0; i < num_triangles; ++i)
+        {
+            int32_t x0 = vertices.data()[i * 6 + 0];
+            int32_t y0 = vertices.data()[i * 6 + 1];
+            int32_t x1 = vertices.data()[i * 6 + 2];
+            int32_t y1 = vertices.data()[i * 6 + 3];
+            int32_t x2 = vertices.data()[i * 6 + 4];
+            int32_t y2 = vertices.data()[i * 6 + 5];
+
+            int64_t cross = static_cast<int64_t>(x1 - x0) * static_cast<int64_t>(y2 - y0) -
+                            static_cast<int64_t>(y1 - y0) * static_cast<int64_t>(x2 - x0);
+            if (cross < 0)
+            {                // Swap vertex 1 and vertex 2 to change winding order
+                std::swap(vertices.data()[i * 6 + 2], vertices.data()[i * 6 + 4]);
+                std::swap(vertices.data()[i * 6 + 3], vertices.data()[i * 6 + 5]);
+            }
+        }
+
         // --- Allocate GPU memory for inputs/outputs ---
         int32_t *d_vertices;
         uint8_t *d_colors;

--- a/src/sushi_cuda/src/cuda_backend.cu
+++ b/src/sushi_cuda/src/cuda_backend.cu
@@ -97,7 +97,7 @@ __global__ void drawloss_kernel_naive_triangle_parallel(
         int32_t w2 = w2_row;
         for (int x = min_x; x <= max_x; ++x)
         {
-            if ((w0 >= 0 && w1 >= 0 && w2 >= 0) || (w0 <= 0 && w1 <= 0 && w2 <= 0))
+            if (w0 <= 0 && w1 <= 0 && w2 <= 0)
             {
                 const int bg_index = (y * background.width + x) * 3;
                 const int tgt_index = (y * target.width + x) * 3;
@@ -179,7 +179,7 @@ __global__ void drawloss_kernel_naive_pixel_parallel(
         const int32_t w2 = edge_function(v0_x, v0_y, v1_x, v1_y, x, y);
 
         int32_t delta_loss = 0;
-        if ((w0 >= 0 && w1 >= 0 && w2 >= 0) || (w0 <= 0 && w1 <= 0 && w2 <= 0)) {
+        if (w0 <= 0 && w1 <= 0 && w2 <= 0) {
             uint8_t out_r, out_g, out_b;
             composit_over(
                 &out_r, &out_g, &out_b,

--- a/sushi/interface.py
+++ b/sushi/interface.py
@@ -332,3 +332,23 @@ class Backend(ABC):
             raise ValueError(
                 f"Unknown mode '{mode}'. Supported modes are 'draw' and 'drawloss'."
             )
+
+
+def count_pixels_batch(
+    vertices: NDArray[np.int32],
+    image_size: int,
+    backend: type["Backend"],
+    backend_config: Optional[Config] = None,
+) -> NDArray[np.int64]:
+    """
+    Calculates the total number of pixels that are covered by each triangle in a batch.
+    """
+    canvas = np.zeros((image_size, image_size, 3), dtype=np.uint8)
+    sample_color = np.array([255, 255, 255, 255], dtype=np.uint8)
+
+    context = backend.create_drawloss_context(
+        background_image=canvas, target_image=canvas, config=backend_config
+    )
+
+    result = context.drawloss(vertices, np.tile(sample_color, (vertices.shape[0], 1)))
+    return (result // (255 * 255 * 3)).astype(np.int64)

--- a/tests/test_rasterization.py
+++ b/tests/test_rasterization.py
@@ -7,22 +7,25 @@ import pytest
 from numpy.typing import NDArray
 from PIL import Image
 
-from sushi.backend.cpp import CPPBackend
-from sushi.backend.cuda import CUDABackend
+from sushi.backend.cpp import CPPBackend, CPPConfig
+from sushi.backend.cuda import CUDABackend, CUDAConfig
 from sushi.backend.numpy import NumpyBackend
 from sushi.backend.opencv import OpenCVBackend
 from sushi.backend.opengl import OpenGLBackend
 from sushi.backend.pillow import PillowBackend
-from sushi.interface import Backend
+from sushi.golden_data import generate_triangles
+from sushi.interface import Backend, Config, count_pixels_batch
 from sushi.utils import np_image_loss
 
-AllBackends = [
-    PillowBackend,
-    NumpyBackend,
-    OpenCVBackend,
-    OpenGLBackend,
-    CPPBackend,
-    CUDABackend,
+AllBackendsToTest = [
+    (PillowBackend, None),
+    (NumpyBackend, None),
+    (OpenCVBackend, None),
+    (OpenGLBackend, None),
+    (CPPBackend, CPPConfig(method="scanline")),
+    (CPPBackend, CPPConfig(method="pointwise")),
+    (CUDABackend, CUDAConfig(method="naive-pixel-parallel")),
+    (CUDABackend, CUDAConfig(method="naive-triangle-parallel")),
 ]
 
 
@@ -67,12 +70,12 @@ def _load_test_image() -> NDArray[np.uint8]:
     return np.array(Image.open(expected_image_path).convert("RGB"))
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def setup_data() -> TestImageData:
     """A pytest fixture to provide common test data."""
     width, height = 200, 150
     image_np = np.full((height, width, 3), 255, dtype=np.uint8)
-    vertices = np.array([(10, 10), (50, 140), (195, 70)], dtype=np.int32)
+    vertices = np.array([(10, 10), (195, 70), (50, 140)], dtype=np.int32)
     color = np.array((200, 55, 79, 192), dtype=np.uint8)
     expected_image_np = _load_test_image()
 
@@ -86,8 +89,126 @@ def setup_data() -> TestImageData:
     )
 
 
-@pytest.mark.parametrize("raster_backend", AllBackends)
-def test_can_clone_drawloss_context(raster_backend: type["Backend"]) -> None:
+@pytest.fixture(scope="module")
+def reference_triangles_dataset() -> NDArray[np.int32]:
+    """A pytest fixture to provide a very large set of test triangles for
+    performance and scalability testing."""
+    return generate_triangles(
+        count=20,
+        screen_width=256,
+        screen_height=256,
+        size="medium",
+        shape_type="random",
+        distribution="uniform",
+        random_rotation=True,
+        random_seed=38,
+    )
+
+
+@pytest.fixture(scope="module")
+def reference_dataset_pixel_counts(
+    reference_triangles_dataset: NDArray[np.int32],
+) -> NDArray[np.int64]:
+    """A pytest fixture to provide a reference pixel counts array for
+    a very large set of test triangles. Calculated using the Numpy backend."""
+    backend = NumpyBackend
+    if not backend.is_available():
+        pytest.skip(
+            f"Reference backend {backend.name} is not available on this system."
+        )
+
+    pixel_counts = count_pixels_batch(
+        vertices=reference_triangles_dataset,
+        image_size=256,
+        backend=backend,
+    )
+
+    return pixel_counts
+
+
+@pytest.mark.parametrize(
+    "raster_backend, config",
+    [(b, c) for b, c in AllBackendsToTest if b != NumpyBackend],
+)
+def test_large_triangle_set_pixel_counts(
+    reference_triangles_dataset: NDArray[np.int32],
+    reference_dataset_pixel_counts: NDArray[np.int64],
+    raster_backend: type["Backend"],
+    config: Optional["Config"],
+) -> None:
+    """
+    Tests that the pixel counting function produces correct counts for a large
+    set of triangles by comparing to a reference dataset generated using the
+    Numpy backend.
+    """
+    maybe_skip_backend(raster_backend, "drawloss")
+
+    pixel_counts = count_pixels_batch(
+        vertices=reference_triangles_dataset,
+        image_size=256,
+        backend=raster_backend,
+        backend_config=config,
+    )
+
+    assert (
+        pixel_counts.shape == reference_dataset_pixel_counts.shape
+    ), "Pixel counts shape mismatch."
+
+    # Define acceptance criteria:
+    # At least 50% of triangle counts must match within a tolerance of 5 pixels or 40%.
+    # At least 60% of triangle counts must match within a tolerance of 10 pixels or 60%.
+    total_triangles = pixel_counts.shape[0]
+    close_matches_fine = 0
+    close_matches_coarse = 0
+    close_match_fine_px_threshold = 5
+    close_match_coarse_px_threshold = 10
+    close_match_fine_pct_threshold = 0.4
+    close_match_coarse_pct_threshold = 0.6
+    for i in range(total_triangles):
+        ref_count = reference_dataset_pixel_counts[i]
+        test_count = pixel_counts[i]
+        abs_diff = abs(int(test_count) - int(ref_count))
+        pct_diff = abs_diff / ref_count if ref_count > 0 else 0
+
+        if (
+            abs_diff <= close_match_fine_px_threshold
+            or pct_diff <= close_match_fine_pct_threshold
+        ):
+            close_matches_fine += 1
+        if (
+            abs_diff <= close_match_coarse_px_threshold
+            or pct_diff <= close_match_coarse_pct_threshold
+        ):
+            close_matches_coarse += 1
+
+    match_rate_fine = close_matches_fine / total_triangles
+    match_rate_coarse = close_matches_coarse / total_triangles
+    assert match_rate_fine >= 0.50, (
+        f"Only {match_rate_fine:.2%} of triangle pixel counts matched "
+        f"within {close_match_fine_px_threshold} pixels or "
+        f"{close_match_fine_pct_threshold * 100}% tolerance."
+    )
+    assert match_rate_coarse >= 0.60, (
+        f"Only {match_rate_coarse:.2%} of triangle pixel counts matched "
+        f"within {close_match_coarse_px_threshold} pixels or "
+        f"{close_match_coarse_pct_threshold * 100}% tolerance."
+    )
+
+    print(
+        f"Backend {raster_backend.name} pixel counting results: "
+        f"{close_matches_fine} / {total_triangles} ({match_rate_fine:.2%}) matched "
+        f"within {close_match_fine_px_threshold} pixels or "
+        f"{close_match_fine_pct_threshold * 100}% tolerance; "
+        f"{close_matches_coarse} / {total_triangles} ({match_rate_coarse:.2%}) matched "
+        f"within {close_match_coarse_px_threshold} pixels or "
+        f"{close_match_coarse_pct_threshold * 100}% tolerance."
+    )
+
+
+@pytest.mark.parametrize("raster_backend, config", AllBackendsToTest)
+def test_can_clone_drawloss_context(
+    raster_backend: type["Backend"], config: Optional["Config"]
+) -> None:
     """
     Tests that the backend's drawloss context can be cloned without errors.
     """
@@ -95,6 +216,7 @@ def test_can_clone_drawloss_context(raster_backend: type["Backend"]) -> None:
     context = raster_backend.create_drawloss_context(
         background_image=np.zeros((10, 10, 3), dtype=np.uint8),
         target_image=np.zeros((10, 10, 3), dtype=np.uint8),
+        config=config,
     )
 
     cloned_context = context.clone()
@@ -104,14 +226,17 @@ def test_can_clone_drawloss_context(raster_backend: type["Backend"]) -> None:
     ), "Cloned context is of incorrect type."
 
 
-@pytest.mark.parametrize("raster_backend", AllBackends)
-def test_can_clone_draw_context(raster_backend: type["Backend"]) -> None:
+@pytest.mark.parametrize("raster_backend, config", AllBackendsToTest)
+def test_can_clone_draw_context(
+    raster_backend: type["Backend"], config: Optional["Config"]
+) -> None:
     """
     Tests that the backend's draw context can be cloned without errors.
     """
     maybe_skip_backend(raster_backend, "draw")
     context = raster_backend.create_draw_context(
-        background_image=np.zeros((10, 10, 3), dtype=np.uint8)
+        background_image=np.zeros((10, 10, 3), dtype=np.uint8),
+        config=config,
     )
 
     cloned_context = context.clone()
@@ -127,9 +252,11 @@ def test_can_clone_draw_context(raster_backend: type["Backend"]) -> None:
     ), "Cloned context is of incorrect type."
 
 
-@pytest.mark.parametrize("raster_backend", AllBackends)
+@pytest.mark.parametrize("raster_backend, config", AllBackendsToTest)
 def test_draw_single_match_reference(
-    setup_data: TestImageData, raster_backend: type["Backend"]
+    setup_data: TestImageData,
+    raster_backend: type["Backend"],
+    config: Optional["Config"],
 ) -> None:
     """
     Tests that drawing a triangle produces the exact expected image by
@@ -157,7 +284,9 @@ def test_draw_single_match_reference(
     color = setup_data.color
     expected_image_np = setup_data.expected_image_np
 
-    context = raster_backend.create_draw_context(background_image=image_np)
+    context = raster_backend.create_draw_context(
+        background_image=image_np, config=config
+    )
 
     drawn_image_np = context.draw(vertices, color)
 
@@ -191,15 +320,17 @@ def test_draw_single_match_reference(
         assert is_close, f"Image does not match reference. See '{failed_image_path}'."
 
 
-@pytest.mark.parametrize("raster_backend", AllBackends)
+@pytest.mark.parametrize("raster_backend, config", AllBackendsToTest)
 def test_count_pixels_single_match_reference(
-    setup_data: TestImageData, raster_backend: type["Backend"]
+    setup_data: TestImageData,
+    raster_backend: type["Backend"],
+    config: Optional["Config"],
 ) -> None:
     """
     Tests that the pixel counting function produces a count close to the
     expected value. The expected value is derived from the saved reference image.
     """
-    maybe_skip_backend(raster_backend, "draw")
+    maybe_skip_backend(raster_backend, "drawloss")
     MATCH_RELATIVE_TOLERANCE = 0.025  # Allow 2.5% tolerance
 
     vertices = setup_data.vertices
@@ -207,10 +338,14 @@ def test_count_pixels_single_match_reference(
         (setup_data.expected_image_np.sum(axis=-1) != (3 * 255)).sum()
     )
 
-    input_image = np.zeros((setup_data.height, setup_data.width, 3), dtype=np.uint8)
-    context = raster_backend.create_draw_context(background_image=input_image)
-    out_image = context.draw(vertices, np.array((255, 255, 255, 255), dtype=np.uint8))
-    counted_pixels = int((out_image.sum(axis=-1) == (3 * 255)).sum())
+    counted_pixels = int(
+        count_pixels_batch(
+            vertices=vertices[np.newaxis, ...],
+            image_size=setup_data.width,
+            backend=raster_backend,
+            backend_config=config,
+        ).sum()
+    )
 
     print(
         f"Backend {raster_backend.name} counted {counted_pixels} pixels, "
@@ -222,9 +357,11 @@ def test_count_pixels_single_match_reference(
     )
 
 
-@pytest.mark.parametrize("raster_backend", AllBackends)
+@pytest.mark.parametrize("raster_backend, config", AllBackendsToTest)
 def test_drawloss_single(
-    setup_data: TestImageData, raster_backend: type["Backend"]
+    setup_data: TestImageData,
+    raster_backend: type["Backend"],
+    config: Optional["Config"],
 ) -> None:
     """
     Tests the draw-loss calculation by comparing the function's output
@@ -249,7 +386,7 @@ def test_drawloss_single(
     expected_loss_change = reference_final_loss - base_loss
 
     context = raster_backend.create_drawloss_context(
-        background_image=image_np, target_image=target_image_np
+        background_image=image_np, target_image=target_image_np, config=config
     )
 
     draw_loss = int(
@@ -265,8 +402,8 @@ def test_drawloss_single(
 
     print(
         f"Backend {raster_backend.name} computed draw loss change of "
-        f"{draw_loss:.6f}, expected {expected_loss_change:.6f}."
-        f" (tolerance {tolerance_bounds[0]:.6f} to {tolerance_bounds[1]:.6f})"
+        f"{draw_loss:.0f}, expected {expected_loss_change:.0f}."
+        f" (tolerance {tolerance_bounds[0]:.0f} to {tolerance_bounds[1]:.0f})"
     )
 
     np.testing.assert_allclose(

--- a/tests/test_rasterization.py
+++ b/tests/test_rasterization.py
@@ -94,7 +94,7 @@ def reference_triangles_dataset() -> NDArray[np.int32]:
     """A pytest fixture to provide a very large set of test triangles for
     performance and scalability testing."""
     return generate_triangles(
-        count=20,
+        count=100,
         screen_width=256,
         screen_height=256,
         size="medium",

--- a/tests/test_rasterization.py
+++ b/tests/test_rasterization.py
@@ -168,7 +168,7 @@ def test_large_triangle_set_pixel_counts(
         ref_count = reference_dataset_pixel_counts[i]
         test_count = pixel_counts[i]
         abs_diff = abs(int(test_count) - int(ref_count))
-        pct_diff = abs_diff / ref_count if ref_count > 0 else 0
+        pct_diff = abs_diff / float(ref_count) if ref_count > 0 else 0.0
 
         if (
             abs_diff <= close_match_fine_px_threshold


### PR DESCRIPTION
This PR adds a statistical test for drawloss by testing the number of pixels matches within a generous tolerance for a large number of triangles in a batch.

This ensures a few things:
- Coverage against failures due to batching
- Coverage against failures for smaller triangles, or triangles with inconsistent winding order
- - This enabled me to implement the winding-order fixup for the CUDA backend
- Regression protection to ensure higher confidence in correctness when making performance improvements

Expected outputs:
```
Backend pillow pixel counting results: 81 / 100 (81.00%) matched within 5 pixels or 40.0% tolerance; 89 / 100 (89.00%) matched within 10 pixels or 60.0% tolerance.
.Backend opencv pixel counting results: 70 / 100 (70.00%) matched within 5 pixels or 40.0% tolerance; 81 / 100 (81.00%) matched within 10 pixels or 60.0% tolerance.
.Backend opengl pixel counting results: 84 / 100 (84.00%) matched within 5 pixels or 40.0% tolerance; 86 / 100 (86.00%) matched within 10 pixels or 60.0% tolerance.
.Backend cpp pixel counting results: 83 / 100 (83.00%) matched within 5 pixels or 40.0% tolerance; 93 / 100 (93.00%) matched within 10 pixels or 60.0% tolerance.
.Backend cpp pixel counting results: 100 / 100 (100.00%) matched within 5 pixels or 40.0% tolerance; 100 / 100 (100.00%) matched within 10 pixels or 60.0% tolerance.
.Backend cuda pixel counting results: 100 / 100 (100.00%) matched within 5 pixels or 40.0% tolerance; 100 / 100 (100.00%) matched within 10 pixels or 60.0% tolerance.
.Backend cuda pixel counting results: 100 / 100 (100.00%) matched within 5 pixels or 40.0% tolerance; 100 / 100 (100.00%) matched within 10 pixels or 60.0% tolerance.
```

OpenGL backend is seeing intermittent failures. This is fine, as it's a low-priority reference implementation. Might be due to winding order. See #11

This PR resolves #7
